### PR TITLE
fixed bugs for creation of user templates

### DIFF
--- a/class/files/TDMCreateHtmlSmartyCodes.php
+++ b/class/files/TDMCreateHtmlSmartyCodes.php
@@ -351,7 +351,7 @@ EOT;
 EOT;
             } elseif (!$noSimbol) {
                 $ret = <<<EOT
-<{if {$condition}{$operator}{$type}}>\n
+<{if \${$condition}{$operator}{$type}}>\n
 EOT;
             } else {
                 $ret = <<<EOT
@@ -369,7 +369,7 @@ EOT;
 EOT;
             } elseif (!$noSimbol) {
                 $ret = <<<EOT
-<{if {$condition}{$operator}{$type}}>\n
+<{if \${$condition}{$operator}{$type}}>\n
 EOT;
             } else {
                 $ret = <<<EOT

--- a/class/files/templates/user/TemplatesUserPages.php
+++ b/class/files/templates/user/TemplatesUserPages.php
@@ -148,7 +148,7 @@ class TemplatesUserPages extends TDMCreateHtmlSmartyCodes
         $cont = $this->htmlcode->getHtmlTag('td', array(), $div).PHP_EOL;
         $html = $this->htmlcode->getHtmlEmpty('</tr><tr>').PHP_EOL;
         $cont   .= $this->htmlcode->getSmartyConditions($tableSolename.'.count', ' is div by ', '$divideby', $html).PHP_EOL;
-        $foreach = $this->htmlcode->getSmartyForeach($tableSolename, $tableName, $cont).PHP_EOL;
+        $foreach = $this->htmlcode->getSmartyForeach($tableSolename, $tableName."_list", $cont).PHP_EOL;
         $tr = $this->htmlcode->getHtmlTag('tr', array(), $foreach).PHP_EOL;
 
         return $this->htmlcode->getHtmlTag('tbody', array(), $tr).PHP_EOL;
@@ -189,7 +189,7 @@ class TemplatesUserPages extends TDMCreateHtmlSmartyCodes
         $table = $this->getTemplatesUserPagesTable($moduleDirname, $tableName, $tableSolename, $language).PHP_EOL;
         $div = $this->htmlcode->getHtmlTag('div', array('class' => 'table-responsive'), $table).PHP_EOL;
 
-        return $this->htmlcode->getSmartyConditions($tableName, ' gt ', '0', $div, false, true).PHP_EOL;
+        return $this->htmlcode->getSmartyConditions($tableName.'_list', ' > ', '0', $div, false, true).PHP_EOL;
     }
 
     /*


### PR DESCRIPTION
replaced gt by >

added missing \$

in the {tablename}.php on user side you say:
$GLOBALS['xoopsTpl']->append('tables1_list', $table1);
in the created tpl you found: <{foreach item=table1 from=$tables1}>
I fixed the bug to get <{foreach item=table1 from=$tables1_list}>
